### PR TITLE
feat: add security policy CRD

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: crossplane-softonic-factory
 description: Crossplane typical templates you'll need in your projects
 type: application
-version: 1.6.5
+version: 1.7.0
 icon: https://crossplane.io/images/favicon_192x192.png
 appVersion: "1.0.0"

--- a/templates/backendService.yaml
+++ b/templates/backendService.yaml
@@ -29,7 +29,8 @@ spec:
     securityPolicy: {{ $value.securityPolicy }}
   {{- end }}
   {{- with $value.logConfig }}
-    logConfig: {{ $value.logConfig }}
+    logConfig:
+      {{- toYaml . | nindent 6 }}
   {{- end }}
   providerConfigRef:
     name: {{ $.Values.providerConfigRef }}

--- a/templates/backendService.yaml
+++ b/templates/backendService.yaml
@@ -28,6 +28,9 @@ spec:
   {{- with $value.securityPolicy }}
     securityPolicy: {{ $value.securityPolicy }}
   {{- end }}
+  {{- with $value.logConfig }}
+    logConfig: {{ $value.logConfig }}
+  {{- end }}
   providerConfigRef:
     name: {{ $.Values.providerConfigRef }}
 {{ end -}}

--- a/templates/securityPolicy.yaml
+++ b/templates/securityPolicy.yaml
@@ -1,8 +1,8 @@
-{{- range $key, $value := $.Values.BackendService -}}
+{{- range $key, $value := $.Values.SecurityPolicy -}}
 {{- $mergedAnnotations := mergeOverwrite dict $.Values.annotations (default dict $value.annotations) }}
 ---
 apiVersion: compute.gcp.upbound.io/v1beta1
-kind: BackendService
+kind: SecurityPolicy
 metadata:
   name: {{ include "crossplane.fullname" $ }}--{{ $key }}
   labels:
@@ -17,16 +17,13 @@ metadata:
   {{- end }}
 spec:
   forProvider:
-    healthChecksSelector:
-      matchLabels:
-        softonic.io/crossplane: {{ include "crossplane.fullname" $ }}--{{ $value.healthChecksSelector }}
-    loadBalancingScheme: {{ $value.loadBalancingScheme }}
-  {{- with $value.backend }}
-    backend:
+  {{- with $value.rule }}
+    rule:
       {{- toYaml . | nindent 6 }}
   {{- end }}
-  {{- with $value.securityPolicy }}
-    securityPolicy: {{ $value.securityPolicy }}
+  {{- with $value.advancedOptionsConfig }}
+    advancedOptionsConfig:
+      {{- toYaml . | nindent 6 }}
   {{- end }}
   providerConfigRef:
     name: {{ $.Values.providerConfigRef }}

--- a/values.test-lb.yaml
+++ b/values.test-lb.yaml
@@ -31,6 +31,7 @@ BackendService:
       - group: "https://www.googleapis.com/compute/beta/projects/kubertonic-st/zones/europe-west1-b/networkEndpointGroups/k8s1-3d2bc877-istio-system-standalone-neg-fhp-80-43bd33ab"
         balancingMode: "RATE"
         maxRate: 100000000
+    securityPolicy: my-external-name
     logConfig:
       - enable: true
         sampleRate: 1

--- a/values.test-lb.yaml
+++ b/values.test-lb.yaml
@@ -31,6 +31,9 @@ BackendService:
       - group: "https://www.googleapis.com/compute/beta/projects/kubertonic-st/zones/europe-west1-b/networkEndpointGroups/k8s1-3d2bc877-istio-system-standalone-neg-fhp-80-43bd33ab"
         balancingMode: "RATE"
         maxRate: 100000000
+    logConfig:
+      - enable: true
+        sampleRate: 1
 
 URLMap:
   my-external-name:
@@ -50,3 +53,33 @@ GlobalForwardingRule:
     loadBalancingScheme: EXTERNAL
     portRange: "443"
     target: "projects/kubertonic-st/global/targetHttpsProxies/my-external-name"
+
+SecurityPolicy:
+  my-external-name:
+    rule:
+      - description: "Ban IPs with more than 1000 reqs/min"
+        action: "rate_based_ban"
+        preview: false
+        priority: 10
+        match:
+          - versionedExpr: "SRC_IPS_V1"
+            config:
+              - srcIpRanges:
+                  - "*"
+        rateLimitOptions:
+          - banDurationSec: 1800
+            conformAction: "allow"
+            enforceOnKey: "IP"
+            exceedAction: "deny(429)"
+            rateLimitThreshold:
+              - count: 1000
+                intervalSec: 60
+      - description: "Default rule"
+        action: "allow"
+        preview: false
+        priority: 2147483647
+        match:
+          - versionedExpr: "SRC_IPS_V1"
+            config:
+              - srcIpRanges:
+                  - "*"

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,8 @@ HealthCheck: {}
 #  name1:
 BackendService: {}
 
+SecurityPolicy: {}
+
 URLMap: {}
 
 TargetHTTPSProxy: {}


### PR DESCRIPTION
Added:
- support for [security policy](https://marketplace.upbound.io/providers/upbound/provider-gcp/v0.33.0/resources/compute.gcp.upbound.io/SecurityPolicy/v1beta1) and the ability to link it to the backend service
- [backend service](https://marketplace.upbound.io/providers/upbound/provider-gcp/v0.33.0/resources/compute.gcp.upbound.io/BackendService/v1beta1) log config