### PR TITLE
The relation between dns and domains is not 1-1

### DIFF
--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -23,7 +23,7 @@ spec:
     managed:
       - dnsAuthorizations:
         {{- range $.Values.dnsMappings }}
-        - projects/projectA/locations/global/dnsAuthorizations/{{ .authorization }}
+        - projects/{{ $value.gcpProjectId }}/locations/global/dnsAuthorizations/{{ .authorization }}
         {{- end }}
         domains:
         {{- range $.Values.dnsMappings }}

--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -22,12 +22,14 @@ spec:
     description: {{ $value.description }}
     managed:
       - dnsAuthorizations:
-        {{- range $key, $val := $.Values.dnsAuthorizations }}
-        - projects/{{ $value.gcpProjectId }}/locations/global/dnsAuthorizations/{{ $key }}
+        {{- range $.Values.dnsMappings }}
+        - projects/projectA/locations/global/dnsAuthorizations/{{ .authorization }}
         {{- end }}
         domains:
-        {{- range $key, $val := $.Values.dnsAuthorizations }}
-        - {{ $val.domain }}
+        {{- range $.Values.dnsMappings }}
+          {{- range .domains }}
+        - {{ . | quote }}
+          {{- end }}
         {{- end }}
     scope: {{ $value.scope }}
 {{ end -}}

--- a/values.test.yaml
+++ b/values.test.yaml
@@ -165,6 +165,14 @@ dnsAuthorizations:
     deletionPolicy: Orphan
     description: "certificate manager for softonic.pl"
     domain: softonic.pl
+dnsMappings:
+  - authorization: "softonic-ru"
+    domains:
+      - "softonic.ru"
+  - authorization: "softonic-pl"
+    domains:
+      - "softonic.pl"
+      - "*.softonic.pl"
 Buckets:
   sft-grafana-prod:
     providerConfigRef: crossplane-bucket-creds


### PR DESCRIPTION
The current configuration of helm allows this config: ( 1 certificate with 1 domain or SAN) 

```
apiVersion: certificatemanager.gcp.upbound.io/v1beta1
kind: Certificate
metadata:
...
spec:
  deletionPolicy: Delete
  forProvider:
    description: certificate manager for 
    managed:
    - dnsAuthorizations:
      - projects/test/locations/global/dnsAuthorizations/example
      domains:
      - example.com
..
```
Sometimes we need 1 certificate with more than 1 SAN , one for wildcard and one without subdomain
So, more than 1 domain for 1 dns authorization

we want to accomplish this:

```
    managed:
      - dnsAuthorizations:
          - projects/test/locations/global/dnsAuthorizations/example
        domains:
          - example.com
          - '*.example.com'
    scope: DEFAULT
```

and the relation is not 1-1 ( we have 1 dnsauth and 2 domains ) 