### PR TITLE
feat: add BucketAccessControl resource

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: crossplane-softonic-factory
 description: Crossplane typical templates you'll need in your projects
 type: application
-version: 1.15.5
+version: 1.15.6
 icon: https://crossplane.io/images/favicon_192x192.png
 appVersion: "1.0.0"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Crossplane Helm Chart
+
 When we use Crossplane we tend to repeat once and over again the same resources, this chart contains the typical crossplane
 resources you'll need in your daily work.
 
 The idea is to add here more resources as they are needed for more projects, for example in the v1.0.0 there aren't any
 resource related to Google Storage Buckets or Databases, but instead of add the Crossplane template/resource in your
-project we propose to you to add the template here allowing to parametrize all you'll need for your project and use 
+project we propose to you to add the template here allowing to parametrize all you'll need for your project and use
 this as a subchart in your definition.
 
 ## Test
@@ -14,6 +15,7 @@ You can test that your template renders correctly executing the command:
 ```shell
 helm template my-example-release --namespace my-example-namespace . -f values.yaml -f values.test.yaml
 ```
+
 You can test the creation of Load Balancer executing the next command:
 
 ```shell
@@ -38,6 +40,7 @@ make publish
 ```
 
 ### Dependencies
+
 - You'll need permissions to write to the helm repository
 - `yq` as dependency
 - make

--- a/templates/bucketAccessControl.yaml
+++ b/templates/bucketAccessControl.yaml
@@ -1,0 +1,44 @@
+{{- range $projectName, $project := .Values.projects }}
+{{- range $providerConfigRefName, $providerConfigRef := $project }}
+{{- range $aclName, $value := $providerConfigRef.BucketAccessControl }}
+{{- $mergedAnnotations := mergeOverwrite dict $.Values.annotations (default dict $value.annotations) }}
+{{- if $value.enabled }}
+---
+apiVersion: storage.gcp.upbound.io/v1beta1
+kind: BucketAccessControl
+metadata:
+  name: {{ $aclName }}
+  labels:
+    softonic.io/crossplane: {{ include "crossplane.fullname" $ }}--{{ $aclName }}
+  {{- with $.Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+  {{- with $mergedAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $value.deletionPolicy }}
+  deletionPolicy: {{ $value.deletionPolicy }}
+  {{- end }}
+  {{- with $value.managementPolicies }}
+  managementPolicies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if and (not $value.deletionPolicy) (not $value.managementPolicies) }}
+  deletionPolicy: Orphan
+  managementPolicies:
+    - Create
+    - Update
+    - Observe
+  {{- end }}
+  forProvider:
+    bucket: "{{ $value.bucket }}"
+    entity: "{{ $value.entity }}"
+    role: "{{ $value.role }}"
+  providerConfigRef:
+    name: {{ $value.providerConfigRef }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/values.test.yaml
+++ b/values.test.yaml
@@ -158,6 +158,14 @@ projects:
           bucket: "sft-grafana-prod"
           member: "serviceAccount:test@kubertonic.iam.gserviceaccount.com"
           role: "projects/kubertonic/roles/softonic_storage_admin"
+      BucketAccessControl:
+        storage-proxy-assets:
+          enabled: true
+          deletionPolicy: Orphan
+          providerConfigRef: crossplane-bucket-creds
+          bucket: "storage-proxy-assets"
+          entity: allUsers
+          role: READER
       Clusters:
         product-europe:
           managementPolicies:


### PR DESCRIPTION
The idea is to be able to migrate this to `crossplane`:
<https://github.com/softonic/wasapi/blob/main/applications/storage-proxy/terraform/modules/storage/main.tf>
For which we are lacking the [BucketAccessControl](https://marketplace.upbound.io/providers/upbound/provider-gcp-storage/v1.8.3/resources/storage.gcp.upbound.io/BucketAccessControl/v1beta1) resource